### PR TITLE
feat(SAR-46705): add s3site_s3 data source for S3 artifact download

### DIFF
--- a/s3site/data_source_s3site_s3.go
+++ b/s3site/data_source_s3site_s3.go
@@ -1,0 +1,55 @@
+package s3site
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceS3() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceS3Read,
+
+		Schema: map[string]*schema.Schema{
+			"bucket": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The S3 bucket containing the artifact.",
+			},
+			"key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The S3 object key of the artifact.",
+			},
+			"path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The local filesystem path where the artifact was downloaded.",
+			},
+		},
+	}
+}
+
+func dataSourceS3Read(data *schema.ResourceData, meta interface{}) error {
+	s3Helper := meta.(*Meta).S3Helper
+
+	bucket := data.Get("bucket").(string)
+	key := data.Get("key").(string)
+
+	data.SetId(fmt.Sprintf("s3://%s/%s", bucket, key))
+
+	if err := prepareTmp(); err != nil {
+		return err
+	}
+
+	localPath := fmt.Sprintf("%s/%s", tempDir, filepath.Base(key))
+
+	if err := s3Helper.GetObject(bucket, key, localPath); err != nil {
+		return err
+	}
+
+	data.Set("path", localPath)
+
+	return nil
+}

--- a/s3site/helper.go
+++ b/s3site/helper.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/md5"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -48,6 +49,34 @@ func NewS3Helper(session *session.Session) *S3Helper {
 	s3Helper.uploader = uploader
 
 	return &s3Helper
+}
+
+func (s3Helper S3Helper) GetObject(bucket string, key string, localPath string) error {
+	s3conn := s3.New(s3Helper.session)
+
+	input := &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	}
+
+	result, err := s3conn.GetObject(input)
+	if err != nil {
+		return fmt.Errorf("error downloading s3://%s/%s: %s", bucket, key, err)
+	}
+	defer result.Body.Close()
+
+	file, err := os.Create(localPath)
+	if err != nil {
+		return fmt.Errorf("error creating local file %s: %s", localPath, err)
+	}
+	defer file.Close()
+
+	if _, err := io.Copy(file, result.Body); err != nil {
+		return fmt.Errorf("error writing to %s: %s", localPath, err)
+	}
+
+	log.Printf("[DEBUG] Downloaded s3://%s/%s to %s", bucket, key, localPath)
+	return nil
 }
 
 func (s3Helper S3Helper) ListS3Objects(bucket string) (*s3.ListObjectsV2Output, error) {

--- a/s3site/provider.go
+++ b/s3site/provider.go
@@ -163,6 +163,7 @@ func Provider() terraform.ResourceProvider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"s3site_artifactory": dataSourceArtifactory(),
+			"s3site_s3":          dataSourceS3(),
 		},
 		ConfigureFunc: providerConfigure,
 	}


### PR DESCRIPTION
## Summary

Adds a new `s3site_s3` data source that downloads artifacts from S3, providing the same `path` output contract as the existing `s3site_artifactory` data source. This is Phase 2 of the Artifactory → S3 migration.

## Changes

- **`s3site/helper.go`**: Added `GetObject(bucket, key, localPath)` method to `S3Helper` — downloads an S3 object to a local file path using the existing AWS session
- **`s3site/data_source_s3site_s3.go`**: New data source with schema:
  - Inputs: `bucket` (string, required), `key` (string, required)
  - Output: `path` (string, computed) — local filesystem path to downloaded artifact
- **`s3site/provider.go`**: Registered `s3site_s3` in `DataSourcesMap`

## Usage

```hcl
data "s3site_s3" "frontend" {
  bucket = "sonrai-global-artifacts"
  key    = "front-end/${var.artifact_version}.zip"
}

resource "s3site_site" "frontend" {
  path   = data.s3site_s3.frontend.path
  bucket = var.site_bucket
}
```

## Design

- Mirrors the `s3site_artifactory` data source contract — `path` output points to downloaded artifact in `/tmp/s3site/`
- Uses the provider's existing AWS session (IAM roles, assume role, credential chain) — no new auth config needed
- Downloads via `s3.GetObject()` from the AWS SDK already in use by the provider

## Migration Plan

This is Phase 2 of 4:
1. ✅ Dual publish frontend ZIP to S3 (front-end PR #9027, merged)
2. **✅ Add S3 data source to provider** (this PR)
3. Switch `infrastructure-modules-sonrai` from Artifactory to S3 data source
4. Remove Artifactory upload from front-end Makefile (cleanup)

Jira: [SAR-46705](https://sonraisecurity.atlassian.net/browse/SAR-46705)

[SAR-46705]: https://sonraisecurity.atlassian.net/browse/SAR-46705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ